### PR TITLE
更新Component當新增內容時，可以將頁面導至最新頁以呈現最新的資料

### DIFF
--- a/next-client/components/common/PaginationComponent/index.js
+++ b/next-client/components/common/PaginationComponent/index.js
@@ -1,25 +1,34 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Pagination } from 'antd'
 
-// 建立 PaginationComponent 组件
 export default function PaginationComponent({
   totalItems,
   pageSize,
   onPageChange,
+  currentPage, // 傳遞當前頁碼
 }) {
-  const [currentPage, setCurrentPage] = useState(1)
+  const [internalCurrentPage, setInternalCurrentPage] = useState(1)
 
-  // 頁數變化
+  useEffect(() => {
+    // 當傳遞的 currentPage 改變時，更新內部的 currentPage
+    setInternalCurrentPage(currentPage)
+  }, [currentPage])
+
   const handlePageChange = (page) => {
-    setCurrentPage(page)
-    onPageChange(page) // 呼叫傳遞進來的 onPageChange
+    setInternalCurrentPage(page)
+    onPageChange(page)
   }
 
   const itemRender = (page, type, originalElement) => {
     if (type === 'prev' || type === 'next') {
       return (
         <>
-          <div className="bg-primary-subtle text-primary">
+          <div
+            className={`bg-primary-subtle text-primary ${
+              page === internalCurrentPage ? 'currentPage' : 'otherPage'
+            }`}
+            style={{ borderRadius: '6px' }}
+          >
             <i
               className={
                 type === 'prev'
@@ -34,9 +43,12 @@ export default function PaginationComponent({
 
     return (
       <div
-        className={
-          currentPage === page ? 'text-light' : 'text-primary bg-primary-subtle'
-        }
+        className={`${
+          page === internalCurrentPage
+            ? 'text-light'
+            : 'text-primary bg-primary-subtle'
+        } ${page === internalCurrentPage ? 'currentPage' : 'otherPage'}`}
+        style={{ borderRadius: '6px' }}
       >
         {originalElement}
       </div>
@@ -44,17 +56,15 @@ export default function PaginationComponent({
   }
 
   return (
-    <>
-      <div className="d-flex justify-content-center">
-        <Pagination
-          current={currentPage}
-          total={totalItems}
-          pageSize={pageSize}
-          onChange={handlePageChange}
-          itemRender={itemRender}
-          showSizeChanger={false}
-        />
-      </div>
-    </>
+    <div className="d-flex justify-content-center">
+      <Pagination
+        current={internalCurrentPage}
+        total={totalItems}
+        pageSize={pageSize}
+        onChange={handlePageChange}
+        itemRender={itemRender}
+        showSizeChanger={false}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
因為新增優惠碼時，想要讓當前頁面為最新頁，所以更新Component
(自己的頁面可以這樣傳遞:
<PaginationComponent
            totalItems={data.length} // 總項目數量
            pageSize={pageSize} // 每頁顯示的項目數量
            currentPage={currentPage} // 目前頁碼
            onPageChange={handlePageChange} // 處理頁碼變化事件的callback funtion
/>
)